### PR TITLE
fix(eip-1193): sign personal_sign payloads as raw bytes

### DIFF
--- a/packages/w3s-web-core-sdk/src/__tests__/providers/eip-1193/provider.test.ts
+++ b/packages/w3s-web-core-sdk/src/__tests__/providers/eip-1193/provider.test.ts
@@ -198,13 +198,19 @@ describe('Providers > eip-1193 > EIP1193Provider > rpc methods', () => {
       method: 'personal_sign',
       params: PersonalSignParams,
     }
+    const signMessageSpy = jest.spyOn(account, 'signMessage')
 
     const response = await provider.request<
       string,
       typeof PersonalSignResponse
     >(mockPayload)
 
+    expect(signMessageSpy).toHaveBeenCalledWith({
+      message: { raw: PersonalSignParams[0] },
+    })
     expect(response).toEqual(PersonalSignResponse)
+
+    signMessageSpy.mockRestore()
   })
 
   it('should throw an error when the to parameter is not provided for eth_sendTransaction', async () => {

--- a/packages/w3s-web-core-sdk/src/providers/eip-1193/provider.ts
+++ b/packages/w3s-web-core-sdk/src/providers/eip-1193/provider.ts
@@ -76,7 +76,7 @@ export default class EIP1193Provider<
         await this.validateAddress(address)
 
         const result = await this.bundlerClient.account!.signMessage({
-          message: challenge,
+          message: { raw: challenge },
         })
 
         return this.getResponse(result, payload)


### PR DESCRIPTION
## Summary

Sign `personal_sign` challenges as raw bytes instead of UTF-8 text.

## Detail

The EIP-1193 provider receives the `personal_sign` challenge as a hex-encoded byte string. Passing that value directly to viem's `signMessage` treats values such as `0xdeadbeef` as the UTF-8 text `"0xdeadbeef"`, producing a signature over different bytes than the caller requested.

This change passes the challenge through viem's `{ raw: challenge }` form and adds a regression assertion covering the arguments sent to the smart account signer.

## Testing

- `jest --runInBand src/__tests__/providers/eip-1193/provider.test.ts` (19 tests passed)
- `tsc --project tsconfig.json --pretty false --noEmit`
- `eslint src/providers/eip-1193/provider.ts src/__tests__/providers/eip-1193/provider.test.ts`
- `git diff --check`

## Documentation

No documentation changes are required; this restores the expected `personal_sign` behavior.
