### PR TITLE
fix(eip-1193): make eth_getTransactionReceipt non-blocking

### DIFF
--- a/packages/w3s-web-core-sdk/src/__mocks__/providers/eip-1193/EIP1193.Mock.ts
+++ b/packages/w3s-web-core-sdk/src/__mocks__/providers/eip-1193/EIP1193.Mock.ts
@@ -96,10 +96,26 @@ export const GetTransactionReceiptParams = ['0xdeadbeef']
 /**
  * Mocks for EIP-1193 rpc responses - eth_getTransactionReceipt.
  */
+export const MockTransactionReceipt = {
+  transactionHash: GetTransactionReceiptParams[0],
+}
+
+/**
+ * Mocks for EIP-1193 rpc responses - eth_getTransactionReceipt.
+ */
 export const MockGetTransactionReceiptResponse = {
   id: undefined,
   jsonrpc: undefined,
-  result: { receipt: { transactionHash: GetTransactionReceiptParams[0] } },
+  result: MockTransactionReceipt,
+}
+
+/**
+ * Mocks for EIP-1193 rpc responses - eth_getTransactionReceipt.
+ */
+export const MockPendingTransactionReceiptResponse = {
+  id: undefined,
+  jsonrpc: undefined,
+  result: null,
 }
 
 /**

--- a/packages/w3s-web-core-sdk/src/__tests__/providers/eip-1193/provider.test.ts
+++ b/packages/w3s-web-core-sdk/src/__tests__/providers/eip-1193/provider.test.ts
@@ -33,8 +33,10 @@ import {
   EthAccountsResponse,
   GetTransactionReceiptParams,
   MockGetTransactionReceiptResponse,
+  MockPendingTransactionReceiptResponse,
   MockSendTransactionResponse,
   MockSendUserOperationResponse,
+  MockTransactionReceipt,
   MockWaitForUserOperationReceiptResponse,
   PersonalSignParams,
   PersonalSignResponse,
@@ -351,23 +353,44 @@ describe('Providers > eip-1193 > EIP1193Provider > rpc methods', () => {
       params: GetTransactionReceiptParams,
     }
 
-    // Spy on `waitForTransactionReceipt`
-    const waitForGetTransactionReceiptSpy = jest
-      .spyOn(publicClient, 'waitForTransactionReceipt')
-      .mockResolvedValue(MockWaitForUserOperationReceiptResponse as never)
+    const requestSpy = jest
+      .spyOn(publicClient, 'request')
+      .mockResolvedValue(MockTransactionReceipt)
 
     const response = await provider.request<
       string,
       typeof MockGetTransactionReceiptResponse
     >(mockPayload)
 
-    expect(waitForGetTransactionReceiptSpy).toHaveBeenCalledWith({
-      hash: GetTransactionReceiptParams[0],
+    expect(requestSpy).toHaveBeenCalledWith({
+      method: 'eth_getTransactionReceipt',
+      params: GetTransactionReceiptParams,
     })
 
     expect(response).toEqual(MockGetTransactionReceiptResponse)
 
-    waitForGetTransactionReceiptSpy.mockRestore()
+    requestSpy.mockRestore()
+  })
+
+  it('should return null for a pending eth_getTransactionReceipt', async () => {
+    const mockPayload = {
+      method: 'eth_getTransactionReceipt',
+      params: GetTransactionReceiptParams,
+    }
+
+    const requestSpy = jest
+      .spyOn(publicClient, 'request')
+      .mockResolvedValue(null)
+
+    const response = await provider.request<
+      string,
+      typeof MockPendingTransactionReceiptResponse
+    >(mockPayload)
+
+    expect(requestSpy).toHaveBeenCalledTimes(1)
+    expect(response).toEqual(MockPendingTransactionReceiptResponse)
+
+    requestSpy.mockRestore()
   })
 
   it('should throw an error when the addresses are different for eth_signTypedData_v4', async () => {

--- a/packages/w3s-web-core-sdk/src/providers/eip-1193/provider.ts
+++ b/packages/w3s-web-core-sdk/src/providers/eip-1193/provider.ts
@@ -107,8 +107,9 @@ export default class EIP1193Provider<
       case 'eth_getTransactionReceipt': {
         const [hash] = params as [Hex]
 
-        const receipt = await this.publicClient.waitForTransactionReceipt({
-          hash,
+        const receipt = await this.publicClient.request({
+          method: 'eth_getTransactionReceipt',
+          params: [hash],
         })
 
         return this.getResponse(receipt, payload)


### PR DESCRIPTION
## Summary

- issue a single `eth_getTransactionReceipt` JSON-RPC request instead of waiting for a mined transaction
- preserve the standard `null` result for pending or unknown transactions
- add regression coverage for both mined and pending receipt responses

## Root cause and impact

`EIP1193Provider` delegated `eth_getTransactionReceipt` to viem's `waitForTransactionReceipt`. That action polls until a receipt is available and has a default timeout, while the JSON-RPC method is a one-shot lookup that must return `null` when no receipt exists yet. As a result, callers could block until the polling timeout for pending or unknown transaction hashes.

## Testing

- `jest --runInBand` (60 suites, 302 tests)
- `tsc --project tsconfig.json --pretty --noEmit`
- `eslint` on the changed source, test, and mock files
